### PR TITLE
Change version string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ group = 'jcpi'
 if (!hasProperty('buildNumber')) {
     ext.buildNumber = 'dev'
 }
-version += '+' + buildNumber
+version += '.' + buildNumber
 
 if (!hasProperty('s3AccessKey')) {
     ext.s3AccessKey = 'n/a'


### PR DESCRIPTION
We now use . instead of the semver + sign to append the build number.
This is because maven does not encode the + sign when requesting a
dependency from a repository and therefore does not find the artifact.
